### PR TITLE
Update CreateLexerCs.cs

### DIFF
--- a/VPKSoft.ScintillaLexers.NET/CreateSpecificLexer/CreateLexerCs.cs
+++ b/VPKSoft.ScintillaLexers.NET/CreateSpecificLexer/CreateLexerCs.cs
@@ -154,7 +154,7 @@ public abstract class CreateLexerCs: CreateLexerCommon
         scintilla.Styles[Style.Cpp.PreprocessorCommentDoc].BackColor =
             lexerColors[LexerType.Cs, "PreprocessorCommentDocBack"];
 
-        scintilla.LexerName = "cpp";
+        scintilla.LexerName = "csharp";
 
         ScintillaKeyWords.SetKeywords(scintilla, LexerType.Cs);
 


### PR DESCRIPTION
Give C# lexer a distinct name ('csharp') to avoid conflict with the C++ lexer 'cpp' as reported in #29 